### PR TITLE
PHP 8 support and update/fixes language paths

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "minimum-stability": "dev",
     "require": {
-        "elementaryframework/fire-fs": "1.0.0"
+        "elementaryframework/fire-fs": "1.2.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Console/Commands/Translation.php
+++ b/src/Console/Commands/Translation.php
@@ -58,7 +58,7 @@ class Translation extends Command
         $watcher = app('watcher');
         $watcher->setListener(new Listener())
             ->setRecursive(true)
-            ->setPath('./resources/lang')
+            ->setPath(lang_path())
             ->setWatchInterval(250)
             ->build();
         $watcher->start();

--- a/src/LaravelTranslationFileHelper.php
+++ b/src/LaravelTranslationFileHelper.php
@@ -32,7 +32,7 @@ class LaravelTranslationFileHelper implements TranslationFileHelper
      */
     public function resourcePath()
     {
-        return resource_path('lang');
+        return lang_path();
     }
 
     /**


### PR DESCRIPTION
Hi @tohidplus 

A PR to support PHP8 and language paths fixes

I know there was a problem with the dependency package elementaryframework/fire-fs in the watcher functionality (https://github.com/tohidplus/laravel-vue-translation/pull/13) so we cannot update this package to PHP8. I have researched this issue and found the problem, was an issue with the paths. https://github.com/ElementaryFramework/FireFS/pull/6#issuecomment-1516817607 the owner created a fix.

Created a laravel-vue-translation forked project with the latest elementaryframework/fire-fs package and now it is working.
I can run the `artisan VueTranslation:generate --watch=1` command without errors (and more important it is working ;) )

But there was another problem in `LaravelTranslationFileHelper.php` the method `resourcePath` was pointing to the `resources/lang` folder but the lang folder is no longer in the resources folder (Laravel 10).
Created a fix for this.

As well in the artisan console command, `setPath` was hardcoded, replaced this with Laravel `lang_path()` helper.

